### PR TITLE
Minimal Setup for GitHub Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+## Project Overview
+
+OneMCP is a dynamic orchestrator for MCP servers. It dynamically discovers and deploys MCP servers
+that will help an agent to solve a task.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+# Copyright(c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install
+      # dependencies, you'll need the `contents: read` permission. If you don't clone the repository
+      # in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"


### PR DESCRIPTION
This pull request introduces documentation and workflow setup updates for the OneMCP project. The changes include adding a project overview to the documentation and creating a GitHub Actions workflow for validating Copilot setup steps.

### Documentation Updates:
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R4): Added a "Project Overview" section describing OneMCP as a dynamic orchestrator for MCP servers that discovers and deploys servers to assist agents in solving tasks.

### Workflow Setup:
* [`.github/copilot-setup-steps.yml`](diffhunk://#diff-0859cf55ca7873553b27a3ad01c3d5588f1bb45881490a2cd05e739d5235c728R1-R52): Added a new GitHub Actions workflow named "Copilot Setup Steps" to validate setup steps automatically and enable manual testing. This workflow supports Python versions 3.10, 3.11, and 3.12, and includes steps for checking out code, setting up Python, caching pip dependencies, and installing project dependencies.