### PR TITLE
Implemented the search tool

### DIFF
--- a/src/onemcp/orchestration/orchestration.py
+++ b/src/onemcp/orchestration/orchestration.py
@@ -1,6 +1,7 @@
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.prompts import base
 from mcp.types import SamplingMessage, TextContent
+
 from ..discovery.mock_registry import MockRegistry
 
 server = FastMCP(
@@ -102,21 +103,21 @@ async def search(query: str, ctx: Context) -> list[base.Message]:
     try:
         # Use the mockRegistry to find similar servers
         similar_servers = mockRegistry.find_similar_servers(query, k=5)
-        
+
         if not similar_servers:
             return [base.Message(role="assistant", content=f"No servers found for query: {query}")]
-        
+
         # Format the results
         results = []
         results.append(f"Found {len(similar_servers)} similar servers for query '{query}':\n")
-        
+
         for i, (server_entry, similarity_score) in enumerate(similar_servers, 1):
             results.append(f"{i}. {server_entry.name} (similarity: {similarity_score:.2f})")
             results.append(f"   URL: {server_entry.url}")
-        
+
         response_text = "\n".join(results)
         return [base.Message(role="assistant", content=response_text)]
-        
+
     except Exception as e:
         return [base.Message(role="assistant", content=f"Search failed: {str(e)}")]
 

--- a/src/onemcp/orchestration/orchestration.py
+++ b/src/onemcp/orchestration/orchestration.py
@@ -77,10 +77,14 @@ async def install(query: str, ctx: Context) -> list[base.Message]:
             max_tokens=50,
         )
         return [
-            base.Message(role="assistant", content="MCP server installation successful.")
+            base.Message(
+                role="assistant", content="MCP server installation successful."
+            )
         ]
     except Exception as e:
-        return [base.Message(role="assistant", content=f"Installation failed: {str(e)}")]
+        return [
+            base.Message(role="assistant", content=f"Installation failed: {str(e)}")
+        ]
 
 
 @server.tool()
@@ -105,14 +109,22 @@ async def search(query: str, ctx: Context) -> list[base.Message]:
         similar_servers = mockRegistry.find_similar_servers(query, k=5)
 
         if not similar_servers:
-            return [base.Message(role="assistant", content=f"No servers found for query: {query}")]
+            return [
+                base.Message(
+                    role="assistant", content=f"No servers found for query: {query}"
+                )
+            ]
 
         # Format the results
         results = []
-        results.append(f"Found {len(similar_servers)} similar servers for query '{query}':\n")
+        results.append(
+            f"Found {len(similar_servers)} similar servers for query '{query}':\n"
+        )
 
         for i, (server_entry, similarity_score) in enumerate(similar_servers, 1):
-            results.append(f"{i}. {server_entry.name} (similarity: {similarity_score:.2f})")
+            results.append(
+                f"{i}. {server_entry.name} (similarity: {similarity_score:.2f})"
+            )
             results.append(f"   URL: {server_entry.url}")
 
         response_text = "\n".join(results)

--- a/src/onemcp/orchestration/orchestration.py
+++ b/src/onemcp/orchestration/orchestration.py
@@ -1,11 +1,20 @@
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.prompts import base
 from mcp.types import SamplingMessage, TextContent
+from ..discovery.mock_registry import MockRegistry
 
 server = FastMCP(
     name="OneMCP Orchestrator",
     description="Dynamic MCP Orchestrator for managing tools and resources",
 )
+
+# Initialize mock registry with some sample servers
+mockRegistry = MockRegistry()
+mockRegistry.register_server("weather-api", "https://github.com/weather/mcp-server")
+mockRegistry.register_server("database-tools", "https://github.com/db/mcp-tools")
+mockRegistry.register_server("file-manager", "https://github.com/files/mcp-manager")
+mockRegistry.register_server("git-helper", "https://github.com/git/mcp-helper")
+mockRegistry.register_server("web-scraper", "https://github.com/web/mcp-scraper")
 
 
 @server.tool()
@@ -67,10 +76,10 @@ async def install(query: str, ctx: Context) -> list[base.Message]:
             max_tokens=50,
         )
         return [
-            base.Message(role="system", content="MCP server installation successful.")
+            base.Message(role="assistant", content="MCP server installation successful.")
         ]
     except Exception as e:
-        return [base.Message(role="system", content=f"Installation failed: {str(e)}")]
+        return [base.Message(role="assistant", content=f"Installation failed: {str(e)}")]
 
 
 @server.tool()
@@ -89,22 +98,27 @@ async def status(query: str, ctx: Context) -> list[base.Message]:
 
 @server.tool()
 async def search(query: str, ctx: Context) -> list[base.Message]:
-    """Searches for a specific resource or tool."""
-    prompt = f"Search for resources or tools related to: {query}"
-
-    result = await ctx.session.create_message(
-        messages=[
-            SamplingMessage(
-                role="user",
-                content=TextContent(type="text", text=prompt),
-            )
-        ],
-        max_tokens=100,
-    )
-
-    if result.content.type == "text":
-        return [base.Message(role="user", content=result.content.text)]
-    return [base.Message(role="user", content=str(result.content))]
+    """Searches for a specific resource or tool using the mock registry."""
+    try:
+        # Use the mockRegistry to find similar servers
+        similar_servers = mockRegistry.find_similar_servers(query, k=5)
+        
+        if not similar_servers:
+            return [base.Message(role="assistant", content=f"No servers found for query: {query}")]
+        
+        # Format the results
+        results = []
+        results.append(f"Found {len(similar_servers)} similar servers for query '{query}':\n")
+        
+        for i, (server_entry, similarity_score) in enumerate(similar_servers, 1):
+            results.append(f"{i}. {server_entry.name} (similarity: {similarity_score:.2f})")
+            results.append(f"   URL: {server_entry.url}")
+        
+        response_text = "\n".join(results)
+        return [base.Message(role="assistant", content=response_text)]
+        
+    except Exception as e:
+        return [base.Message(role="assistant", content=f"Search failed: {str(e)}")]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces enhancements to the `OneMCP Orchestrator` by integrating a mock registry for server discovery and updating the behavior of several orchestration tools. The changes improve server search functionality, refine message roles for responses, and add dynamic server registration.

### Mock Registry Integration and Server Discovery:

* [`src/onemcp/orchestration/orchestration.py`](diffhunk://#diff-3d98dd3078653ec68d813eb21ff346847d16bb3238bc983cabef628c9ef9e6c8R5-R19): Added `MockRegistry` initialization and registered sample servers (`weather-api`, `database-tools`, `file-manager`, `git-helper`, `web-scraper`) for dynamic server discovery. This enables the `search` tool to utilize the registry for finding similar servers.

* `async def search(query: str, ctx: Context) -> list[base.Message]`: Updated the `search` tool to use the `mockRegistry` for finding servers matching the query. Results are formatted to include server names, similarity scores, and URLs. Added error handling for failed searches.

### Message Role Refinements:

* `async def install(query: str, ctx: Context) -> list[base.Message]`: Changed the role of response messages from `system` to `assistant` for consistency in user-facing outputs.